### PR TITLE
Adding support for folder jobs (like Multibranch jobs)

### DIFF
--- a/src/main/java/io/morethan/jenkins/jmhreport/ProjectJmhView.java
+++ b/src/main/java/io/morethan/jenkins/jmhreport/ProjectJmhView.java
@@ -62,7 +62,7 @@ public class ProjectJmhView implements Action, Serializable {
 		String contextPath = Stapler.getCurrentRequest().getContextPath();
 		Run<?, ?> lastSuccessfulBuild = getProject().getLastSuccessfulBuild();
 		String providedId = lastSuccessfulBuild == null ? "none" : Integer.toString(lastSuccessfulBuild.getNumber());
-		return new StringBuilder(contextPath).append("/job/").append(getProject().getName()).append('/')
+		return new StringBuilder(contextPath).append("/").append(getProject().getUrl())
 				.append(URL_NAME).append("/provided-").append(providedId).append(".js").toString();
 	}
 

--- a/src/main/java/io/morethan/jenkins/jmhreport/RunJmhView.java
+++ b/src/main/java/io/morethan/jenkins/jmhreport/RunJmhView.java
@@ -75,8 +75,7 @@ public class RunJmhView implements Action, LastBuildAction, Serializable {
 
 	public String getProvidedJsUrl() {
 		String contextPath = Stapler.getCurrentRequest().getContextPath();
-		return new StringBuilder(contextPath).append("/job/").append(getProjectName()).append('/')
-				.append(getBuildNumber()).append('/').append(URL_NAME).append("/provided-").append(getBuildNumber())
+		return new StringBuilder(contextPath).append("/").append(getRun().getUrl()).append(URL_NAME).append("/provided-").append(getBuildNumber())
 				.append(".js").toString();
 	}
 


### PR DESCRIPTION
When the jobs are present inside a folder, the path to the Project and a build were wrong. This made the report to now show up and instead generate a JS error in the web console of the browser.

This PR fixes that by picking the URL from the API instead of creating it ourself.