### PR TITLE
Remove unnecessary checkout arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ OR
 A complete pipeline could look like that:
 ```
 node {
-    checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/ben-manes/caffeine.git']]])
+    checkout([$class: 'GitSCM', branches: [[name: '*/master']], userRemoteConfigs: [[url: 'https://github.com/ben-manes/caffeine.git']]])
     sh './gradlew jmh -PincludePattern=".*DelegationBenchmark.*"'
     jmhReport 'caffeine/build/reports/jmh/results.json'
 }


### PR DESCRIPTION
## Remove unnecessary checkout arguments from example

Default value is sufficient for extensions: []

Git plugin 4.6.0 no longer suggests doGenerateSubmoduleConfigurations or submoduleCfg from the snipper generator.  The previous values were defaults that are assumed by the git plugin when they are not specified.